### PR TITLE
OSR 130 zurück button

### DIFF
--- a/src/_includes/layouts/project.liquid
+++ b/src/_includes/layouts/project.liquid
@@ -138,8 +138,12 @@ permalink: /projekt/{{ id | slug }}/
   </div>
   <div class="col-span-12 md:col-span-7 mt-12 md:mt-0">
     {% include partials/breadcrumbs.liquid %}
-    <article class="mt-12 prose">
+    <article class="mt-12 prose mb-16">
       {{ content }}
     </article>
+    <a href="/projekte" rel="noopener noreferrer" class="component-button sm:w-2/5 md:w-3/5 flex float-right justify-center items-center">
+      <span class="inline-block pr-2">{% include partials/icon-back.html %}</span>
+      <span class="ml-1">Zur Projekt-Übersicht</span>
+    </a>
   </div>
 </div>

--- a/src/_includes/layouts/project.liquid
+++ b/src/_includes/layouts/project.liquid
@@ -142,8 +142,4 @@ permalink: /projekt/{{ id | slug }}/
       {{ content }}
     </article>
   </div>
-  <aside class="col-span-12 mt-12">
-    <h2 class="mx-auto text-center">Alle Projekte auf einen Blick</h2>
-    <div class="mt-8">{% include partials/project-overview.liquid %}</div>
-  </aside>
 </div>

--- a/src/_includes/layouts/project.liquid
+++ b/src/_includes/layouts/project.liquid
@@ -141,7 +141,7 @@ permalink: /projekt/{{ id | slug }}/
     <article class="mt-12 prose mb-16">
       {{ content }}
     </article>
-    <a href="/projekte" rel="noopener noreferrer" class="component-button sm:w-2/5 md:w-3/5 flex float-right justify-center items-center">
+    <a href="/projekte" rel="noopener noreferrer" class="group component-button sm:w-2/5 md:w-3/5 flex float-right justify-center items-center">
       <span class="inline-block pr-2">{% include partials/icon-back.html %}</span>
       <span class="ml-1">Zur Projekt-Übersicht</span>
     </a>

--- a/src/_includes/partials/icon-back.html
+++ b/src/_includes/partials/icon-back.html
@@ -2,7 +2,7 @@
     <defs>
       <polygon id="icon-next-a" points="14 1.41 12.59 0 5.59 7 12.59 14 14 12.59 8.41 7"/>
     </defs>
-    <g fill="none" fill-rule="evenodd" transform="translate(-5 0)">
+    <g fill="none" fill-rule="evenodd" transform="translate(-5 -1)">
       <rect width="12" height="2" y="6"/>
       <use class="group-hover:fill-current" fill="#24387D" fill-rule="nonzero" transform="rotate(0 0 0)" xlink:href="#icon-next-a"/>
     </g>

--- a/src/_includes/partials/icon-back.html
+++ b/src/_includes/partials/icon-back.html
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="11" height="21" viewBox="0 0 9 12">
+    <defs>
+      <polygon id="icon-next-a" points="14 1.41 12.59 0 5.59 7 12.59 14 14 12.59 8.41 7"/>
+    </defs>
+    <g fill="none" fill-rule="evenodd" transform="translate(-5 0)">
+      <rect width="12" height="2" y="6"/>
+      <use class="group-hover:fill-current" fill="#24387D" fill-rule="nonzero" transform="rotate(0 0 0)" xlink:href="#icon-next-a"/>
+    </g>
+  </svg>

--- a/src/tag.liquid
+++ b/src/tag.liquid
@@ -12,6 +12,7 @@ pagination:
 permalink: /tag/{{ tag | slug }}/
 eleventyComputed:
   title: "{{ tag | capitalize }}"
+tags: project
 ---
 
 <ul class="mt-4 md:mt-12 mb-16 grid md:grid-cols-2 gap-4 md:gap-8">

--- a/src/tag.liquid
+++ b/src/tag.liquid
@@ -24,7 +24,7 @@ tags: project
   </li>
   {% endfor %}
 </ul>
-<a href="/projekte" rel="noopener noreferrer" class="component-button sm:w-2/5 md:w-2/7 flex float-right justify-center items-center">
+<a href="/projekte" rel="noopener noreferrer" class="group component-button sm:w-2/5 md:w-2/7 flex float-right justify-center items-center">
   <span class="inline-block md:pr-2">{% include partials/icon-back.html %}</span>
   <span class="ml-1">Zur Projekt-Übersicht</span>
 </a>

--- a/src/tag.liquid
+++ b/src/tag.liquid
@@ -14,7 +14,7 @@ eleventyComputed:
   title: "{{ tag | capitalize }}"
 ---
 
-<ul class="mt-4 md:mt-12 mb-12 grid md:grid-cols-2 gap-4 md:gap-8">
+<ul class="mt-4 md:mt-12 mb-16 grid md:grid-cols-2 gap-4 md:gap-8">
   {% for project in collections[tag] %}
   <li>
     {% include partials/project-card.liquid, url: project.url, title:
@@ -23,3 +23,7 @@ eleventyComputed:
   </li>
   {% endfor %}
 </ul>
+<a href="/projekte" rel="noopener noreferrer" class="component-button sm:w-2/5 md:w-2/7 flex float-right justify-center items-center">
+  <span class="inline-block md:pr-2">{% include partials/icon-back.html %}</span>
+  <span class="ml-1">Zur Projekt-Übersicht</span>
+</a>


### PR DESCRIPTION
- Implementation of a "Zurück zur Projekt-Übersicht"-button for all project sub-pages and tag pages.
- Also fixed missing part ">Projekte>" in breadcrumb for tag sites.
- Deleted project overview from project sub-pages
