### PR TITLE
fix(OSR-151): get issue count from correct API

### DIFF
--- a/utils/requests.ts
+++ b/utils/requests.ts
@@ -1,5 +1,5 @@
 import nodeFetch from "node-fetch";
-import { GithubResponseType } from "./types";
+import { GithubResponseType, GithubSearchApiResponseType } from "./types";
 
 require("dotenv").config();
 
@@ -29,6 +29,31 @@ export const fetchGithubRepo: (
     );
 
     return (await response.json()) as GithubResponseType;
+  } catch (error) {
+    throw new Error(error);
+  }
+};
+
+export const fetchOpenIssues: (
+  url: string
+) => Promise<GithubSearchApiResponseType> = async (url) => {
+  const isAuthorized = process.env.API_TOKEN_GITHUB;
+  const options = isAuthorized
+    ? {
+        headers: {
+          Authorization: `token ${process.env.API_TOKEN_GITHUB}`,
+        },
+      }
+    : {};
+
+  try {
+    const response = await nodeFetch(url, options);
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch. Status: ${response.status}`);
+    }
+
+    return (await response.json()) as GithubSearchApiResponseType;
   } catch (error) {
     throw new Error(error);
   }

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -35,3 +35,9 @@ export interface GithubDataType {
   timestamp: Date;
   repos: RepoObjectType | {};
 }
+
+export interface GithubSearchApiResponseType {
+  total_count: number;
+  // there is much more data coming:
+  [key: string]: unknown;
+}


### PR DESCRIPTION
The previously used GitHub API returns combined issues + PRs for `open_issues_count`.

Now we use the GitHub search API which actually returns the count for issues only. Other values are still fetched from the GitHub API.