### PR TITLE
updated badegewaesser link

### DIFF
--- a/src/projects/Berliner-Badestellen.md
+++ b/src/projects/Berliner-Badestellen.md
@@ -6,7 +6,7 @@ title: Berliner Badestellen
 abstract: Übersicht über Berliner Badestellen mit aktuellen Informationen zur Wasserqualität
 languages: ["Typescript"]
 license: MIT
-link: https://badestellen.netlify.app/
+link: https://www.badegewaesser-berlin.de
 repository: https://github.com/technologiestiftung/flusshygiene
 developers: ["Technologiestiftung Berlin"]
 backers: ["Senatsverwaltung für Wirtschaft, Energie und Betriebe"]


### PR DESCRIPTION
updated: 
Badegewaesser Link is now up and running again.
Replaced temporary netlify link with https://www.badegewaesser-berlin.de