### PR TITLE
fix(OSR-162): allow project background images to be loaded

### DIFF
--- a/src/_includes/layouts/root.liquid
+++ b/src/_includes/layouts/root.liquid
@@ -8,7 +8,7 @@ defaultAbstract: Überblick über Open Source-Projekte, die im Land Berlin von �
   <head>
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'none'; connect-src 'self' https://piwik.technologiestiftung-berlin.de; img-src 'self' https://piwik.technologiestiftung-berlin.de; script-src 'self' https://piwik.technologiestiftung-berlin.de; style-src 'self'; font-src 'self'; manifest-src 'self'; object-src 'none'"
+      content="default-src 'none'; connect-src 'self' https://piwik.technologiestiftung-berlin.de; img-src 'self' https://piwik.technologiestiftung-berlin.de; script-src 'self' https://piwik.technologiestiftung-berlin.de; style-src 'self' 'unsafe-inline'; font-src 'self'; manifest-src 'self'; object-src 'none'"
     />
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
The CSP had restricted inline-loaded CSS. However, we need this to dynamically set the background images of the project pages' hero sections.

Allowing `unsafe-inline` is obviously not ideal, but it is currently necessary.
