### PR TITLE
fix: nav menu toggle and error handling in requests

### DIFF
--- a/src/assets/js/nav.js
+++ b/src/assets/js/nav.js
@@ -5,9 +5,11 @@ let isMenuOpen = false;
 menuButton.addEventListener("click", () => {
   isMenuOpen = !isMenuOpen;
   menuButton.setAttribute("aria-expanded", isMenuOpen);
-  isMenuOpen
-    ? menuContent.classList.add("block") &
-      menuContent.classList.remove("hidden")
-    : menuContent.classList.add("hidden") &
-      menuContent.classList.remove("block");
+  if (isMenuOpen) {
+    menuContent.classList.remove("hidden");
+    menuContent.classList.add("block");
+  } else {
+    menuContent.classList.remove("block");
+    menuContent.classList.add("hidden");
+  }
 });

--- a/utils/requests.ts
+++ b/utils/requests.ts
@@ -30,7 +30,8 @@ export const fetchGithubRepo: (
 
     return (await response.json()) as GithubResponseType;
   } catch (error) {
-    throw new Error(error);
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`GitHub repo fetch failed: ${message}`);
   }
 };
 
@@ -55,6 +56,7 @@ export const fetchOpenIssues: (
 
     return (await response.json()) as GithubSearchApiResponseType;
   } catch (error) {
-    throw new Error(error);
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`GitHub issues fetch failed: ${message}`);
   }
 };


### PR DESCRIPTION
## What

Two small bug fixes I spotted while reading through the codebase.

### nav.js — bitwise `&` used instead of `;`

The menu toggle was using the bitwise AND operator to chain classList operations. It works by accident but it's not the intended behavior — replaced with a plain if/else.

### requests.ts — `throw new Error(error)` loses error info

When `error` is an Error object, wrapping it in `new Error(error)` calls `.toString()` on it which gives `[object Object]` or a mangled message. Now we extract the message properly before re-throwing.

## Test

- Checked nav toggle still works (open/close)
- No changes to the build or any config